### PR TITLE
Add FreeBSD amd64 support

### DIFF
--- a/pytonlib/tonlibjson.py
+++ b/pytonlib/tonlibjson.py
@@ -65,6 +65,8 @@ def get_tonlib_path():
         lib_name = f'libtonlibjson.{machine}.so'
     elif arch_name == 'darwin':
         lib_name = f'libtonlibjson.{machine}.dylib'
+    elif arch_name == 'freebsd':
+        lib_name = f'libtonlibjson.{machine}.so'
     elif arch_name == 'windows':
         lib_name = f'tonlibjson.{machine}.dll'
     else:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     package_data={
         'pytonlib': ['distlib/linux/*',
                      'distlib/darwin/*',
+                     'distlib/freebsd/*',
                      'distlib/windows/*',],
         'pytonlib.utils': [],
         '': ['requirements.txt']


### PR DESCRIPTION
This PR will add FreeBSD amd64 support to pytonlib.

Library build on FreeBSD 13 host using `-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=znver2 -Ofast -ffast-math"` flags