### PR TITLE
Fixed 'coroutine was never awaited' error

### DIFF
--- a/pytonlib/client.py
+++ b/pytonlib/client.py
@@ -311,7 +311,7 @@ class TonlibClient:
 
     async def raw_create_and_send_query(self, destination, body, init_code=b'', init_data=b'', *args, **kwargs):
         query_info = await self._raw_create_query(destination, body, init_code, init_data)
-        return self._raw_send_query(query_info)
+        return await self._raw_send_query(query_info)
 
     async def raw_create_and_send_message(self, destination, body, initial_account_state=b'', *args, **kwargs):
         # Very close to raw_create_and_send_query, but StateInit should be generated outside


### PR DESCRIPTION
Error example:
```
Traceback (most recent call last):
  File "C:\test\ton-http-api\python310\lib\multiprocessing\queues.py", line 244, in _feed
    obj = _ForkingPickler.dumps(obj)
  File "C:\test\ton-http-api\python310\lib\multiprocessing\reduction.py", line 51, in dumps
    cls(buf, protocol).dump(obj)
TypeError: cannot pickle 'coroutine' object
C:\test\ton-http-api\python310\lib\multiprocessing\queues.py:236: RuntimeWarning: coroutine 'TonlibClient._raw_send_query' was never awaited
  obj = bpopleft()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```