### PR TITLE
Fix: Handle 500 Error on Retrieving Transactions with Expired LT

### DIFF
--- a/pytonlib/client.py
+++ b/pytonlib/client.py
@@ -385,6 +385,9 @@ class TonlibClient:
         all_transactions = []
         current_lt, curret_hash = from_transaction_lt, from_transaction_hash
         while (not reach_lt) and (len(all_transactions) < limit):
+            if current_lt <= to_transaction_lt:
+                reach_lt = True
+                break
             raw_transactions = await self.raw_get_transactions(account, current_lt, curret_hash)
             transactions, next = raw_transactions['transactions'], raw_transactions.get("previous_transaction_id")
             for t in transactions:


### PR DESCRIPTION
### Issue

Currently, the getTransactions returns 500 error when attempting to retrieve a transaction with an expired LT

```
{
  "ok": false,
  "error": "LITE_SERVER_UNKNOWN: cannot locate transaction in block with specified logical time",
  "code": 500
}
```

### Proposed Solution
Prior to fetching transactions using LT, implement a check to ensure that the LT is less than `toLt`
