### PR TITLE
Add Custom Library-Specific Exceptions

### DIFF
--- a/pytonlib/client.py
+++ b/pytonlib/client.py
@@ -5,6 +5,7 @@ import struct
 import logging
 import os
 
+from pytonlib.exceptions import SmartContractIsNotJettonOrNft
 from pytonlib.tonlibjson import TonLib
 from pytonlib.utils.address import prepare_address, detect_address
 from pytonlib.utils.common import b64str_to_hex, hex_to_b64str, hash_to_hex
@@ -872,7 +873,7 @@ class TonlibClient:
                 get_method_result_stack = get_method_results[i]['stack']
 
         if contract_type is None or get_method_result_stack is None:
-            raise Exception("Smart contract is not Jetton or NFT")
+            raise SmartContractIsNotJettonOrNft()
         
         result = None
         if contract_type == 'jetton_master':

--- a/pytonlib/exceptions.py
+++ b/pytonlib/exceptions.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+
+class PyTonLibException(Exception):
+    """Base class for exceptions in the PyTONLib library."""
+
+    message = "An error occurred in the PyTONLib library"
+
+    def __init__(self, message: Optional[str] = None):
+        super().__init__(message or self.message)
+
+
+class SmartContractIsNotJettonOrNft(PyTonLibException):
+    """Raised when the smart contract is not a Jetton or NFT."""
+
+    message = "Smart contract is not a Jetton or NFT"


### PR DESCRIPTION
# GitHub Issue

https://github.com/toncenter/pytonlib/issues/67

# Description

This PR introduces custom exceptions to enhance error handling in PyTONLib, enabling dependent projects to catch and handle specific error cases more reliably.

# Key Changes

- Added `PyTonLibException` as the base class for library-specific exceptions.
- Introduced `SmartContractIsNotJettonOrNft` to handle cases where a smart contract is neither a Jetton nor an NFT.
